### PR TITLE
[Fix] Retrieve app key window

### DIFF
--- a/NotificationBanner/Classes/BaseNotificationBanner.swift
+++ b/NotificationBanner/Classes/BaseNotificationBanner.swift
@@ -151,12 +151,8 @@ open class BaseNotificationBanner: UIView {
     /// The main window of the application which banner views are placed on
     private let appWindow: UIWindow? = {
         if #available(iOS 13.0, *) {
-            return UIApplication.shared.connectedScenes
-                .first { $0.activationState == .foregroundActive || $0.activationState == .foregroundInactive }
-                .map { $0 as? UIWindowScene }
-                .map { $0?.windows.first } ?? UIApplication.shared.delegate?.window ?? UIApplication.shared.keyWindow
+            return UIApplication.shared.windows.filter { $0.isKeyWindow }.first
         }
-
         return UIApplication.shared.delegate?.window ?? nil
     }()
 


### PR DESCRIPTION
This fixes the crashes due to bannerPositionFrame being nil (due to window being nil); as mentioned in issues #333 and #286 in original repo.